### PR TITLE
Potential Fallback Provider (Solves #22)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,15 @@ const essentialEth = new JsonRpcProvider(
 const essentialEth = new JsonRpcProvider();
 ```
 
+If you want to use a fallback provider in case your main provider fails:
+
+```typescript
+import { FallbackProvider } from 'essential-eth';
+const essentialEth = new FallbackProvider(
+  ['RPC URL HERE', 'BACKUP RPC URL HERE'] /* Try POKT or Infura */,
+);
+```
+
 #### `getNetwork`
 
 Returns a [Network](src/types/Network.types.ts)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { Contract } from './classes/Contract';
 import { JsonRpcProvider, jsonRpcProvider } from './providers/JsonRpcProvider';
+import { FallbackProvider } from './providers/FallbackProvider';
 import { tinyBig, TinyBig } from './shared/tiny-big/tiny-big';
 import { Block } from './types/Block.types';
 import {
@@ -19,6 +20,7 @@ export {
   isAddress,
   jsonRpcProvider,
   JsonRpcProvider,
+  FallbackProvider,
   tinyBig,
   toChecksumAddress,
   weiToEther,

--- a/src/providers/FallbackProvider.ts
+++ b/src/providers/FallbackProvider.ts
@@ -1,0 +1,44 @@
+import { cleanBlock } from '../classes/utils/clean-block';
+import { buildRPCPostBody, post } from '../classes/utils/fetchers';
+import { hexToDecimal } from '../classes/utils/hex-to-decimal';
+import { Block, RPCBlock } from '../types/Block.types';
+import { Network } from '../types/Network.types';
+import { JsonRpcProvider } from './JsonRpcProvider';
+import chainsInfo from './utils/chains-info';
+export class FallbackProvider {
+  /**
+   * The URL to your Eth node. Consider POKT or Infura
+   */
+  _rpcUrls: Array<string>;
+  constructor(rpcUrls?: Array<string>) {
+    this._rpcUrls = rpcUrls || [
+      'https://free-eth-junk.com/api/eth',
+      'https://free-eth-node.com/api/eth',
+    ];
+  }
+
+  /**
+   * Returns the block requested
+   * Same as `web3.eth.getBlock`
+   */
+  public async getBlock(
+    timeFrame:
+      | 'latest'
+      | 'earliest'
+      | 'pending'
+      | number /* block number as integer */,
+    returnTransactionObjects = false,
+  ): Promise<Block> {
+    const firstCall = new JsonRpcProvider(this._rpcUrls[0]);
+    return firstCall.getBlock('latest').catch((e) => {
+      const secondCall = new JsonRpcProvider(this._rpcUrls[1]);
+      return secondCall.getBlock('latest');
+    });
+  }
+}
+/**
+ * Helper function to avoid "new"
+ */
+export function jsonRpcProvider(rpcUrl?: string) {
+  return new JsonRpcProvider(rpcUrl);
+}

--- a/src/providers/test/get-block.test.ts
+++ b/src/providers/test/get-block.test.ts
@@ -1,7 +1,7 @@
 import Big from 'big.js';
 import omit from 'just-omit';
 import Web3 from 'web3';
-import { Block, JsonRpcProvider } from '../..';
+import { Block, JsonRpcProvider, FallbackProvider } from '../..';
 
 const rpcUrl = `${process.env.RPC_ORIGIN}/api/eth`;
 
@@ -27,6 +27,18 @@ describe('matches web3', () => {
 
   it('should get latest block', async () => {
     const essentialEth = new JsonRpcProvider(rpcUrl);
+    const web3 = new Web3(rpcUrl);
+    const [eeLatestBlock, web3LatestBlock] = await Promise.all([
+      essentialEth.getBlock('latest'),
+      web3.eth.getBlock('latest'),
+    ]);
+    testBlockEquality(eeLatestBlock, web3LatestBlock as unknown as Block);
+  });
+  it('should get latest block -- backup', async () => {
+    const essentialEth = new FallbackProvider([
+      'https://free-eth-junk.com/api/eth',
+      'https://free-eth-node.com/api/eth',
+    ]);
     const web3 = new Web3(rpcUrl);
     const [eeLatestBlock, web3LatestBlock] = await Promise.all([
       essentialEth.getBlock('latest'),


### PR DESCRIPTION
Inelegant but functional way to add a fallback provider in case the first JSONRpc fails. Currently only supports one other RPC, i.e. one preferred RPC and one fallback.

Not ready to be merged into main but can be forked and used in situations where this functionality is crucial.