### PR TITLE
Force `interface`s instead of `type`s using ESLint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,5 +28,6 @@ module.exports = {
     'jest/no-commented-out-tests': 'warn',
     'jest/require-hook': 'warn',
     '@typescript-eslint/ban-ts-comment': 'warn',
+    '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
   },
 };

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,10 @@
 name: 🧪 npm test
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
+  # push:
+  #   branches: [master]
 
 jobs:
   build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3585,9 +3585,9 @@
       }
     },
     "@types/prettier": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.0.tgz",
-      "integrity": "sha512-WHRsy5nMpjXfU9B0LqOqPT06EI2+8Xv5NERy0pLxJLbU98q7uhcGogQzfX+rXpU7S5mgHsLxHrLCufZcV/P8TQ==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-2.4.4.tgz",
+      "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
       "dev": true
     },
     "@types/qs": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@types/jest": "^27.4.1",
     "@types/jest-dev-server": "^5.0.0",
     "@types/node": "^16.10.1",
-    "@types/prettier": "^2.4.0",
+    "@types/prettier": "^2.4.4",
     "@types/supertest": "^2.0.11",
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",

--- a/src/classes/Contract.ts
+++ b/src/classes/Contract.ts
@@ -13,9 +13,9 @@ function estimateGas(txnData: string) {
     return previousValue + characterCost;
   }, 0);
 }
-type Options = {
+interface Options {
   gasLimit?: number;
-};
+}
 export class BaseContract {
   /**
    * The URL to your Eth node. Consider POKT or Infura

--- a/src/shared/tiny-big/helpers.test.ts
+++ b/src/shared/tiny-big/helpers.test.ts
@@ -20,15 +20,11 @@ describe('scientificStrToDecimalStr', () => {
     expect(scientificStrToDecimalStr('0100e-4')).toBe('0.01');
     expect(scientificStrToDecimalStr('010.1e-3')).toBe('0.0101');
     expect(scientificStrToDecimalStr('-010.1e-3')).toBe('-0.0101');
-    expect(scientificStrToDecimalStr('09.1e-51')).toBe(
-      `0.${'0'.repeat(50)}91`,
-    );
+    expect(scientificStrToDecimalStr('09.1e-51')).toBe(`0.${'0'.repeat(50)}91`);
   });
   it('positive power', () => {
     expect(scientificStrToDecimalStr('01e2')).toBe('100');
     expect(scientificStrToDecimalStr('-01e2')).toBe('-100');
-    expect(scientificStrToDecimalStr('09.1e51')).toBe(
-      `91${'0'.repeat(50)}`,
-    );
+    expect(scientificStrToDecimalStr('09.1e51')).toBe(`91${'0'.repeat(50)}`);
   });
 });

--- a/src/types/Contract.types.ts
+++ b/src/types/Contract.types.ts
@@ -44,7 +44,7 @@ export type ContractTypes =
   | string;
 export type ContractInterface = JSONABI;
 export type ContractFunction<T = any> = (...args: Array<any>) => Promise<T>;
-export type JSONABIArgument = {
+export interface JSONABIArgument {
   anonymous?: false;
   inputs: {
     internalType?: ContractTypes | string;
@@ -63,5 +63,5 @@ export type JSONABIArgument = {
   gas?: number;
   constant?: boolean;
   payable?: boolean;
-};
+}
 export type JSONABI = JSONABIArgument[];

--- a/src/types/Network.types.ts
+++ b/src/types/Network.types.ts
@@ -1,8 +1,8 @@
 /**
  * A trimmed version of https://chainid.network/chains.json
  */
-export type Network = {
+export interface Network {
   chainId: number;
   ensAddress: string | null; // ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
   name: string;
-};
+}

--- a/src/utils/tests/ether-to-wei.test.ts
+++ b/src/utils/tests/ether-to-wei.test.ts
@@ -8,25 +8,15 @@ describe('ether-to-wei', () => {
   it('happy path', () => {
     expect(etherToWei('100').toString()).toBe('100000000000000000000');
     expect(etherToWei(100).toString()).toBe('100000000000000000000');
-    expect(etherToWei('1000.0').toString()).toBe(
-      '1000000000000000000000',
-    );
+    expect(etherToWei('1000.0').toString()).toBe('1000000000000000000000');
     expect(etherToWei(1000).toString()).toBe('1000000000000000000000');
-    expect(etherToWei('1000.0').toNumber()).toBe(
-      1000000000000000000000,
-    );
-    expect(etherToWei(tinyBig(1000)).toString()).toBe(
-      '1000000000000000000000',
-    );
+    expect(etherToWei('1000.0').toNumber()).toBe(1000000000000000000000);
+    expect(etherToWei(tinyBig(1000)).toString()).toBe('1000000000000000000000');
     expect(etherToWei(tinyBig('1000.0')).toNumber()).toBe(
       1000000000000000000000,
     );
-    expect(etherToWei(Big(1000)).toString()).toBe(
-      '1000000000000000000000',
-    );
-    expect(etherToWei(Big('1000.0')).toNumber()).toBe(
-      1000000000000000000000,
-    );
+    expect(etherToWei(Big(1000)).toString()).toBe('1000000000000000000000');
+    expect(etherToWei(Big('1000.0')).toNumber()).toBe(1000000000000000000000);
   });
 
   it('matches ethers and web3 toString', () => {

--- a/src/utils/tests/wei-to-ether.test.ts
+++ b/src/utils/tests/wei-to-ether.test.ts
@@ -5,27 +5,17 @@ import { tinyBig, weiToEther } from '../../index';
 
 describe('wei-to-ether', () => {
   it('happy path', () => {
-    expect(weiToEther('100000000000000000000.0').toString()).toBe(
-      '100',
-    );
+    expect(weiToEther('100000000000000000000.0').toString()).toBe('100');
     expect(weiToEther(100000000000000000000.0).toString()).toBe('100');
-    expect(weiToEther('1000000000000000000000.0').toNumber()).toBe(
-      1000,
-    );
+    expect(weiToEther('1000000000000000000000.0').toNumber()).toBe(1000);
     expect(weiToEther(1000000000000000000000.0).toNumber()).toBe(1000);
 
-    expect(
-      weiToEther(tinyBig('1000000000000000000000.0')).toNumber(),
-    ).toBe(1000);
-    expect(
-      weiToEther(tinyBig(1000000000000000000000.0)).toNumber(),
-    ).toBe(1000);
-    expect(
-      weiToEther(Big('1000000000000000000000.0')).toNumber(),
-    ).toBe(1000);
-    expect(weiToEther(Big(1000000000000000000000.0)).toNumber()).toBe(
+    expect(weiToEther(tinyBig('1000000000000000000000.0')).toNumber()).toBe(
       1000,
     );
+    expect(weiToEther(tinyBig(1000000000000000000000.0)).toNumber()).toBe(1000);
+    expect(weiToEther(Big('1000000000000000000000.0')).toNumber()).toBe(1000);
+    expect(weiToEther(Big(1000000000000000000000.0)).toNumber()).toBe(1000);
   });
 
   describe('matches ethers and web3 toString', () => {


### PR DESCRIPTION
Resolves #30

The approach I used is a little different than what was commented in #30, just because the ESLint Typescript library linked was merged into a better maintained repo. I believe this is the equivalent rule, but definitely correct me if I'm wrong!