### PR TITLE
ESLint Reject `.skip` and `.only` in Jest Testing

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,6 +27,7 @@ module.exports = {
     'jest/no-disabled-tests': 'warn',
     'jest/no-commented-out-tests': 'warn',
     'jest/require-hook': 'warn',
+    'jest/no-conditional-expect': 'error',
     '@typescript-eslint/ban-ts-comment': 'warn',
     '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
   },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,5 +28,6 @@ module.exports = {
     'jest/no-commented-out-tests': 'warn',
     'jest/require-hook': 'warn',
     '@typescript-eslint/ban-ts-comment': 'warn',
+    '@typescript-eslint/consistent-type-definitions': ['error', 'interface'],
   },
 };

--- a/src/classes/Contract.ts
+++ b/src/classes/Contract.ts
@@ -13,9 +13,9 @@ function estimateGas(txnData: string) {
     return previousValue + characterCost;
   }, 0);
 }
-type Options = {
+interface Options {
   gasLimit?: number;
-};
+}
 export class BaseContract {
   /**
    * The URL to your Eth node. Consider POKT or Infura

--- a/src/types/Contract.types.ts
+++ b/src/types/Contract.types.ts
@@ -44,7 +44,7 @@ export type ContractTypes =
   | string;
 export type ContractInterface = JSONABI;
 export type ContractFunction<T = any> = (...args: Array<any>) => Promise<T>;
-export type JSONABIArgument = {
+export interface JSONABIArgument {
   anonymous?: false;
   inputs: {
     internalType?: ContractTypes | string;
@@ -63,5 +63,5 @@ export type JSONABIArgument = {
   gas?: number;
   constant?: boolean;
   payable?: boolean;
-};
+}
 export type JSONABI = JSONABIArgument[];

--- a/src/types/Network.types.ts
+++ b/src/types/Network.types.ts
@@ -1,8 +1,8 @@
 /**
  * A trimmed version of https://chainid.network/chains.json
  */
-export type Network = {
+export interface Network {
   chainId: number;
   ensAddress: string | null; // ensAddress: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e';
   name: string;
-};
+}


### PR DESCRIPTION
Resolves #41 