### PR TITLE
Revert multi-json-rpc #44

### DIFF
--- a/src/classes/Contract.ts
+++ b/src/classes/Contract.ts
@@ -66,7 +66,7 @@ export class BaseContract {
                   : null;
               const req = async (): Promise<string> => {
                 return await post(
-                  this._provider._rpcUrl[this._provider._rpcUrlCounter],
+                  this._provider._rpcUrl,
                   buildRPCPostBody('eth_call', [
                     {
                       to: this._address.toLowerCase(),
@@ -78,12 +78,7 @@ export class BaseContract {
                     },
                     'latest',
                   ]),
-                ).catch((e) => {
-                  if (e.code === 'ENOTFOUND') {
-                    this._provider._rpcUrlCounter++;
-                    return req();
-                  }
-                });
+                );
               };
               const nodeResponse = await req();
               return decodeRPCResponse(jsonABIArgument, nodeResponse);

--- a/src/classes/Contract.ts
+++ b/src/classes/Contract.ts
@@ -70,7 +70,7 @@ export class BaseContract {
                   buildRPCPostBody('eth_call', [
                     {
                       to: this._address.toLowerCase(),
-                      data: data,
+                      data,
                       // sometimes gas is defined in the ABI
                       ...(decimalGas
                         ? { gas: `0x${decimalGas.toString(16)}` }

--- a/src/providers/JsonRpcProvider.ts
+++ b/src/providers/JsonRpcProvider.ts
@@ -9,18 +9,9 @@ export class JsonRpcProvider {
   /**
    * The URL to your Eth node. Consider POKT or Infura
    */
-  readonly _rpcUrl: Array<string>;
-  _rpcUrlCounter: number;
-  constructor(rpcUrl?: string | Array<string>) {
-    this._rpcUrl = ((): Array<string> => {
-      if (!rpcUrl) {
-        return ['https://free-eth-node.com/api/eth'];
-      } else if (!Array.isArray(rpcUrl)) {
-        return [rpcUrl];
-      }
-      return rpcUrl;
-    })();
-    this._rpcUrlCounter = 0;
+  readonly _rpcUrl: string;
+  constructor(rpcUrl?: string) {
+    this._rpcUrl = rpcUrl || 'https://free-eth-node.com/api/eth';
   }
 
   /**
@@ -45,18 +36,12 @@ export class JsonRpcProvider {
     }
     const req = async (): Promise<RPCBlock> => {
       return await post(
-        this._rpcUrl[this._rpcUrlCounter],
+        this._rpcUrl,
         buildRPCPostBody('eth_getBlockByNumber', [
           rpcTimeFrame,
           returnTransactionObjects,
         ]),
-      ).catch((e) => {
-        if (e.code === 'ENOTFOUND') {
-          this._rpcUrlCounter++;
-          return req();
-        }
-        throw e;
-      });
+      );
     };
     const nodeResponse = (await req()) as RPCBlock;
 
@@ -67,16 +52,7 @@ export class JsonRpcProvider {
    */
   public async getNetwork(): Promise<Network> {
     const req = async (): Promise<string> => {
-      return await post(
-        this._rpcUrl[this._rpcUrlCounter],
-        buildRPCPostBody('eth_chainId', []),
-      ).catch((e) => {
-        if (e.code === 'ENOTFOUND') {
-          this._rpcUrlCounter++;
-          return req();
-        }
-        throw e;
-      });
+      return await post(this._rpcUrl, buildRPCPostBody('eth_chainId', []));
     };
     const nodeResponse = (await req()) as string;
     const chainId = hexToDecimal(nodeResponse);
@@ -93,16 +69,7 @@ export class JsonRpcProvider {
    */
   public async getGasPrice(): Promise<TinyBig> {
     const req = async (): Promise<string> => {
-      return await post(
-        this._rpcUrl[this._rpcUrlCounter],
-        buildRPCPostBody('eth_gasPrice', []),
-      ).catch((e) => {
-        if (e.code === 'ENOTFOUND') {
-          this._rpcUrlCounter++;
-          return req();
-        }
-        throw e;
-      });
+      return await post(this._rpcUrl, buildRPCPostBody('eth_gasPrice', []));
     };
     const nodeResponse = (await req()) as string; /* '0x153cfb1ad0' */
     return tinyBig(hexToDecimal(nodeResponse));

--- a/src/providers/test/get-block.test.ts
+++ b/src/providers/test/get-block.test.ts
@@ -36,17 +36,6 @@ describe('provider.getBlock happy path', () => {
     ]);
     testBlockEquality(eeLatestBlock, web3LatestBlock as unknown as Block);
   });
-  it('should get latest block, uses fallback when first URL fails', async () => {
-    const essentialEthFallbackProvider = new JsonRpcProvider([
-      'https://invalid-url.test',
-      rpcUrl,
-    ]);
-    const [eeEarliestBlock, web3EarliestBlock] = await Promise.all([
-      essentialEthFallbackProvider.getBlock('earliest'),
-      web3Provider.eth.getBlock('earliest'),
-    ]);
-    testBlockEquality(eeEarliestBlock, web3EarliestBlock as unknown as Block);
-  });
   it('should get earliest block', async () => {
     const [eeEarliestBlock, web3EarliestBlock] = await Promise.all([
       essentialEthProvider.getBlock('earliest'),

--- a/test/global-setup.js
+++ b/test/global-setup.js
@@ -3,6 +3,6 @@ const { setup } = require('jest-dev-server');
 module.exports = async function globalSetup() {
   await setup({
     command: `node test/server`,
-    launchTimeout: 10000,
+    launchTimeout: 15000,
   });
 };


### PR DESCRIPTION
Unfortunately there were issues with infinite addition of the counter. This creates `undefined` array element access and instant production issues whenever an RPC endpoint goes down. The only fix would be to restart the server so that the rpc counter returns to 0.

Reverts #44 