### PR TITLE
:bug: Changed TinyBig to throw error with message instead of console.error message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1281,9 +1281,9 @@
       }
     },
     "@ethersproject/providers": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.3.tgz",
-      "integrity": "sha512-PKTEZXjdAhGK/+hUwRLQqlGrwTRrK4D0FHEP2V9klUF8C6+AWfHkA3AoLI+a8oq5CUZoRAH0nMecYGkKxUjeSw==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/@ethersproject/providers/-/providers-5.6.4.tgz",
+      "integrity": "sha512-WAdknnaZ52hpHV3qPiJmKx401BLpup47h36Axxgre9zT+doa/4GC/Ne48ICPxTm0BqndpToHjpLP1ZnaxyE+vw==",
       "dev": true,
       "requires": {
         "@ethersproject/abstract-provider": "^5.6.0",
@@ -4477,9 +4477,9 @@
       }
     },
     "ethers": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.3.tgz",
-      "integrity": "sha512-TkZAYGtbnzsGzEzqonLEMpOkmD5JIKCoWlAlj9ShAJlJszEkgKh3jVSeX1edLkYmqnpvJvGlBDK2y/HVe84LNg==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.6.4.tgz",
+      "integrity": "sha512-62UIfxAQXdf67TeeOaoOoPctm5hUlYgfd0iW3wxfj7qRYKDcvvy0f+sJ3W2/Pyx77R8dblvejA8jokj+lS+ATQ==",
       "dev": true,
       "requires": {
         "@ethersproject/abi": "5.6.1",
@@ -4500,7 +4500,7 @@
         "@ethersproject/networks": "5.6.2",
         "@ethersproject/pbkdf2": "5.6.0",
         "@ethersproject/properties": "5.6.0",
-        "@ethersproject/providers": "5.6.3",
+        "@ethersproject/providers": "5.6.4",
         "@ethersproject/random": "5.6.0",
         "@ethersproject/rlp": "5.6.0",
         "@ethersproject/sha2": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "dotenv": "^16.0.0",
     "eslint": "^8.13.0",
     "eslint-plugin-jest": "^26.1.4",
-    "ethers": "^5.6.3",
+    "ethers": "^5.6.4",
     "express": "^4.17.1",
     "husky": "^4.3.0",
     "jest": "^27.5.1",

--- a/src/shared/tiny-big/tiny-big.ts
+++ b/src/shared/tiny-big/tiny-big.ts
@@ -10,8 +10,7 @@ export class TinyBig extends Big {
     try {
       super(value);
     } catch (e) {
-      console.error(`TinyBig cannot parse value (value=${value})`);
-      throw e;
+      throw new Error(`TinyBig cannot parse value (value=${value})`);
     }
   }
   /**


### PR DESCRIPTION
Closes #71 by throwing error with specific on incorrect type, instead of logging error through console and throwing an unhelpful error message.