### PR TITLE
✨Added `getTransactionReceipt` function

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "ts-jest": "^27.1.4",
         "ts-node": "^10.2.1",
         "typedoc": "^0.22.13",
-        "typescript": "^4.6.3",
+        "typescript": "^4.6.4",
         "web3": "^1.7.3"
       }
     },
@@ -11362,9 +11362,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -20709,9 +20709,9 @@
       }
     },
     "typescript": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
-      "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+      "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
     "ultron": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ts-jest": "^27.1.4",
     "ts-node": "^10.2.1",
     "typedoc": "^0.22.13",
-    "typescript": "^4.6.3",
+    "typescript": "^4.6.4",
     "web3": "^1.7.3"
   },
   "dependencies": {

--- a/src/classes/utils/clean-transaction-receipt.ts
+++ b/src/classes/utils/clean-transaction-receipt.ts
@@ -1,0 +1,51 @@
+import { tinyBig, toChecksumAddress } from '../..';
+import {
+  RPCTransactionReceipt,
+  TransactionReceiptResponse,
+} from '../../types/Transaction.types';
+import { hexToDecimal } from './hex-to-decimal';
+
+/**
+ * Converts RPC transaction receipt response to more JS-friendly format
+ */
+export function cleanTransactionReceipt(
+  transactionReceipt: RPCTransactionReceipt,
+): TransactionReceiptResponse {
+  const cleanedTransactionReceipt = {
+    ...transactionReceipt,
+  } as unknown as TransactionReceiptResponse;
+  (
+    Object.keys(transactionReceipt) as Array<keyof RPCTransactionReceipt>
+  ).forEach((key) => {
+    if (!transactionReceipt[key]) return;
+    switch (key) {
+      case 'blockNumber':
+      case 'status':
+      case 'transactionIndex':
+      case 'type':
+        cleanedTransactionReceipt[key] = Number(
+          hexToDecimal(transactionReceipt[key]),
+        );
+        break;
+      case 'contractAddress':
+      case 'from':
+      case 'to':
+        if (transactionReceipt[key]) {
+          cleanedTransactionReceipt[key] = toChecksumAddress(
+            transactionReceipt[key],
+          );
+        }
+        break;
+      case 'cumulativeGasUsed':
+      case 'effectiveGasPrice':
+      case 'gasUsed':
+        cleanedTransactionReceipt[key] = tinyBig(
+          hexToDecimal(transactionReceipt[key]),
+        );
+        break;
+      case 'logs':
+        
+    }
+  });
+  return cleanedTransactionReceipt;
+}

--- a/src/classes/utils/clean-transaction-receipt.ts
+++ b/src/classes/utils/clean-transaction-receipt.ts
@@ -1,5 +1,6 @@
 import { tinyBig, toChecksumAddress } from '../..';
 import {
+  RPCLog,
   RPCTransactionReceipt,
   TransactionReceipt,
 } from '../../types/Transaction.types';
@@ -41,6 +42,26 @@ export function cleanTransactionReceipt(
         );
         break;
       case 'logs':
+        transactionReceipt[key].forEach((log: RPCLog, index: number) => {
+          (Object.keys(log) as Array<keyof RPCLog>).forEach((logKey) => {
+            switch (logKey) {
+              case 'address':
+                cleanedTransactionReceipt[key][index][logKey] =
+                  toChecksumAddress(log[logKey]);
+                break;
+              case 'blockNumber':
+              case 'logIndex':
+              case 'transactionIndex':
+                cleanedTransactionReceipt[key][index][logKey] = Number(
+                  hexToDecimal(log[logKey]),
+                );
+                break;
+              case 'removed':
+                delete log[logKey];
+                break;
+            }
+          });
+        });
     }
   });
   cleanedTransactionReceipt.byzantium =

--- a/src/classes/utils/clean-transaction-receipt.ts
+++ b/src/classes/utils/clean-transaction-receipt.ts
@@ -3,6 +3,7 @@ import {
   RPCTransactionReceipt,
   TransactionReceipt,
 } from '../../types/Transaction.types';
+import { cleanTransaction } from './clean-transaction';
 import { hexToDecimal } from './hex-to-decimal';
 
 /**
@@ -11,25 +12,21 @@ import { hexToDecimal } from './hex-to-decimal';
 export function cleanTransactionReceipt(
   transactionReceipt: RPCTransactionReceipt,
 ): TransactionReceipt {
+  const cleanedTransaction = cleanTransaction(transactionReceipt as any);
   const cleanedTransactionReceipt = {
-    ...transactionReceipt,
+    ...cleanedTransaction,
   } as unknown as TransactionReceipt;
   (
     Object.keys(transactionReceipt) as Array<keyof RPCTransactionReceipt>
   ).forEach((key) => {
     if (!transactionReceipt[key]) return;
     switch (key) {
-      case 'blockNumber':
       case 'status':
-      case 'transactionIndex':
-      case 'type':
         cleanedTransactionReceipt[key] = Number(
           hexToDecimal(transactionReceipt[key]),
         );
         break;
       case 'contractAddress':
-      case 'from':
-      case 'to':
         if (transactionReceipt[key]) {
           cleanedTransactionReceipt[key] = toChecksumAddress(
             transactionReceipt[key],

--- a/src/classes/utils/clean-transaction-receipt.ts
+++ b/src/classes/utils/clean-transaction-receipt.ts
@@ -1,7 +1,7 @@
 import { tinyBig, toChecksumAddress } from '../..';
 import {
   RPCTransactionReceipt,
-  TransactionReceiptResponse,
+  TransactionReceipt,
 } from '../../types/Transaction.types';
 import { hexToDecimal } from './hex-to-decimal';
 
@@ -10,10 +10,10 @@ import { hexToDecimal } from './hex-to-decimal';
  */
 export function cleanTransactionReceipt(
   transactionReceipt: RPCTransactionReceipt,
-): TransactionReceiptResponse {
+): TransactionReceipt {
   const cleanedTransactionReceipt = {
     ...transactionReceipt,
-  } as unknown as TransactionReceiptResponse;
+  } as unknown as TransactionReceipt;
   (
     Object.keys(transactionReceipt) as Array<keyof RPCTransactionReceipt>
   ).forEach((key) => {
@@ -44,8 +44,9 @@ export function cleanTransactionReceipt(
         );
         break;
       case 'logs':
-        
     }
   });
+  cleanedTransactionReceipt.byzantium =
+    cleanedTransactionReceipt.blockNumber >= 4370000;
   return cleanedTransactionReceipt;
 }

--- a/src/classes/utils/fetchers.ts
+++ b/src/classes/utils/fetchers.ts
@@ -34,6 +34,7 @@ type RPCMethodName =
   | 'eth_gasPrice'
   | 'eth_getBalance'
   | 'eth_getTransactionByHash'
+  | 'eth_getTransactionReceipt'
   | 'eth_getTransactionCount';
 export function buildRPCPostBody(method: RPCMethodName, params: unknown[]) {
   return {

--- a/src/providers/BaseProvider.ts
+++ b/src/providers/BaseProvider.ts
@@ -193,6 +193,15 @@ export abstract class BaseProvider {
   }
 
   /**
+   * Gives information about a transaction that has already been mined. Includes additional information beyond what's provided by `getTransaction()`
+   *
+   * * Similar to [`ethers.provider.getTransactionReceipt`](https://docs.ethers.io/v5/api/providers/provider/#Provider-getTransactionReceipt), some information not included
+   *
+   * @param transactionHash the hash of the transaction to get information about
+   *
+   */
+
+  /**
    * Returns the transaction count from genesis up to specified blockTag
    *
    * * Same as `ethers.provider.getTransactionCount`

--- a/src/providers/BaseProvider.ts
+++ b/src/providers/BaseProvider.ts
@@ -201,6 +201,19 @@ export abstract class BaseProvider {
    *
    */
 
+  public async getTransactionReceipt(transactionHash: string): Promise<any> {
+    const [rpcTransaction, blockNumber] = await Promise.all([
+      this.post(
+        buildRPCPostBody('eth_getTransactionReceipt', [transactionHash])
+      ) as Promise<RPCTransaction>,
+      this.getBlock('latest')
+    ]);
+    const cleanedTransaction = cleanTransaction(rpcTransaction);
+    cleanedTransaction.confirmations =
+      blockNumber.number - cleanedTransaction.blockNumber + 1;
+    return cleanedTransaction
+  }
+
   /**
    * Returns the transaction count from genesis up to specified blockTag
    *

--- a/src/providers/BaseProvider.ts
+++ b/src/providers/BaseProvider.ts
@@ -1,5 +1,6 @@
 import { cleanBlock } from '../classes/utils/clean-block';
 import { cleanTransaction } from '../classes/utils/clean-transaction';
+import { cleanTransactionReceipt } from '../classes/utils/clean-transaction-receipt';
 import { buildRPCPostBody, post } from '../classes/utils/fetchers';
 import { hexToDecimal } from '../classes/utils/hex-to-decimal';
 import { TinyBig, tinyBig } from '../shared/tiny-big/tiny-big';
@@ -7,6 +8,8 @@ import { BlockResponse, BlockTag, RPCBlock } from '../types/Block.types';
 import { Network } from '../types/Network.types';
 import {
   RPCTransaction,
+  RPCTransactionReceipt,
+  TransactionReceipt,
   TransactionResponse,
 } from '../types/Transaction.types';
 import chainsInfo from './utils/chains-info';
@@ -201,17 +204,19 @@ export abstract class BaseProvider {
    *
    */
 
-  public async getTransactionReceipt(transactionHash: string): Promise<any> {
+  public async getTransactionReceipt(
+    transactionHash: string,
+  ): Promise<TransactionReceipt> {
     const [rpcTransaction, blockNumber] = await Promise.all([
       this.post(
-        buildRPCPostBody('eth_getTransactionReceipt', [transactionHash])
-      ) as Promise<RPCTransaction>,
-      this.getBlock('latest')
+        buildRPCPostBody('eth_getTransactionReceipt', [transactionHash]),
+      ) as Promise<RPCTransactionReceipt>,
+      this.getBlock('latest'),
     ]);
-    const cleanedTransaction = cleanTransaction(rpcTransaction);
-    cleanedTransaction.confirmations =
-      blockNumber.number - cleanedTransaction.blockNumber + 1;
-    return cleanedTransaction
+    const cleanedTransactionReceipt = cleanTransactionReceipt(rpcTransaction);
+    cleanedTransactionReceipt.confirmations =
+      blockNumber.number - cleanedTransactionReceipt.blockNumber + 1;
+    return cleanedTransactionReceipt;
   }
 
   /**

--- a/src/providers/test/json-rpc-provider/get-transaction-receipt.test.ts
+++ b/src/providers/test/json-rpc-provider/get-transaction-receipt.test.ts
@@ -1,7 +1,7 @@
 import { ethers } from 'ethers';
 import omit from 'just-omit';
 import { JsonRpcProvider } from '../../../index';
-import { TransactionResponse } from '../../../types/Transaction.types';
+import { TransactionReceipt } from '../../../types/Transaction.types';
 import { rpcUrls } from '../rpc-urls';
 
 const rpcUrl = rpcUrls.mainnet;
@@ -18,24 +18,17 @@ describe('provider.getTransactionReceipt', () => {
       'effectiveGasPrice',
     ];
     const omittedTransaction1 = omit(transaction1, [
+      'logs', // temporary
       ...bignumCheckKeys,
     ]);
     const omittedTransaction2 = omit(transaction2, [
+      'logs', // temporary
       ...bignumCheckKeys,
     ]);
     expect(omittedTransaction1).toStrictEqual(omittedTransaction2);
     expect(
       Math.abs(transaction1.confirmations - transaction2.confirmations),
     ).toBeLessThan(3);
-    bignumCheckKeys.forEach((key) => {
-      let ethersKey = key as keyof ethers.providers.TransactionResponse;
-      if (key === 'gas') {
-        ethersKey = 'gasLimit';
-      }
-      expect((transaction1 as any)[ethersKey].toString()).toBe(
-        (transaction2 as any)[key].toString(),
-      );
-    });
   }
   // it('should match web3 and essential-eth', async () => {
   //   const transactionHash =
@@ -54,11 +47,15 @@ describe('provider.getTransactionReceipt', () => {
       '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
     const ethersProvider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
     const essentialEthProvider = new JsonRpcProvider(rpcUrl);
-    const [ethersTransactionReceipt, essentialEthTransactionReceipt] = await Promise.all([
-      ethersProvider.getTransactionReceipt(transactionHash),
-      essentialEthProvider.getTransactionReceipt(transactionHash),
-    ]);
+    const [ethersTransactionReceipt, essentialEthTransactionReceipt] =
+      await Promise.all([
+        ethersProvider.getTransactionReceipt(transactionHash),
+        essentialEthProvider.getTransactionReceipt(transactionHash),
+      ]);
 
-    testTransactionEquality(ethersTransactionReceipt, essentialEthTransactionReceipt);
+    testTransactionEquality(
+      ethersTransactionReceipt,
+      essentialEthTransactionReceipt,
+    );
   });
 });

--- a/src/providers/test/json-rpc-provider/get-transaction-receipt.test.ts
+++ b/src/providers/test/json-rpc-provider/get-transaction-receipt.test.ts
@@ -14,7 +14,7 @@ describe('provider.getTransactionReceipt', () => {
     // requires manually comparing values via bigNum conversion
     const bignumCheckKeys = [
       'gasUsed',
-      'cumulativeGasPrice',
+      'cumulativeGasUsed',
       'effectiveGasPrice',
     ];
     const omittedTransaction1 = omit(transaction1, [
@@ -29,6 +29,12 @@ describe('provider.getTransactionReceipt', () => {
     expect(
       Math.abs(transaction1.confirmations - transaction2.confirmations),
     ).toBeLessThan(3);
+    bignumCheckKeys.forEach((key) => {
+      const ethersKey = key as keyof ethers.providers.TransactionResponse;
+      expect((transaction1 as any)[ethersKey].toString()).toBe(
+        (transaction2 as any)[key].toString(),
+      );
+    });
   }
   // it('should match web3 and essential-eth', async () => {
   //   const transactionHash =

--- a/src/providers/test/json-rpc-provider/get-transaction-receipt.test.ts
+++ b/src/providers/test/json-rpc-provider/get-transaction-receipt.test.ts
@@ -1,0 +1,64 @@
+import { ethers } from 'ethers';
+import omit from 'just-omit';
+import { JsonRpcProvider } from '../../../index';
+import { TransactionResponse } from '../../../types/Transaction.types';
+import { rpcUrls } from '../rpc-urls';
+
+const rpcUrl = rpcUrls.mainnet;
+
+describe('provider.getTransactionReceipt', () => {
+  function testTransactionEquality(
+    transaction1: ethers.providers.TransactionReceipt,
+    transaction2: TransactionReceipt,
+  ) {
+    // requires manually comparing values via bigNum conversion
+    const bignumCheckKeys = [
+      'gasUsed',
+      'cumulativeGasPrice',
+      'effectiveGasPrice',
+    ];
+    const omittedTransaction1 = omit(transaction1, [
+      ...bignumCheckKeys,
+    ]);
+    const omittedTransaction2 = omit(transaction2, [
+      ...bignumCheckKeys,
+    ]);
+    expect(omittedTransaction1).toStrictEqual(omittedTransaction2);
+    expect(
+      Math.abs(transaction1.confirmations - transaction2.confirmations),
+    ).toBeLessThan(3);
+    bignumCheckKeys.forEach((key) => {
+      let ethersKey = key as keyof ethers.providers.TransactionResponse;
+      if (key === 'gas') {
+        ethersKey = 'gasLimit';
+      }
+      expect((transaction1 as any)[ethersKey].toString()).toBe(
+        (transaction2 as any)[key].toString(),
+      );
+    });
+  }
+  // it('should match web3 and essential-eth', async () => {
+  //   const transactionHash =
+  //     '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
+  //   const web3Provider = new Web3(rpcUrl);
+  //   const essentialEthProvider = new JsonRpcProvider(rpcUrl);
+  //   const [web3Transaction, essentialEthTransaction] = await Promise.all([
+  //     web3Provider.eth.getTransaction(transactionHash),
+  //     essentialEthProvider.getTransaction(transactionHash),
+  //   ]);
+
+  //   testTransactionEquality(web3Transaction as any, essentialEthTransaction);
+  // });
+  it('should match ethers and essential-eth', async () => {
+    const transactionHash =
+      '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
+    const ethersProvider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
+    const essentialEthProvider = new JsonRpcProvider(rpcUrl);
+    const [ethersTransactionReceipt, essentialEthTransactionReceipt] = await Promise.all([
+      ethersProvider.getTransactionReceipt(transactionHash),
+      essentialEthProvider.getTransactionReceipt(transactionHash),
+    ]);
+
+    testTransactionEquality(ethersTransactionReceipt, essentialEthTransactionReceipt);
+  });
+});

--- a/src/providers/test/json-rpc-provider/get-transaction-receipt.test.ts
+++ b/src/providers/test/json-rpc-provider/get-transaction-receipt.test.ts
@@ -1,5 +1,7 @@
 import { ethers } from 'ethers';
 import omit from 'just-omit';
+import Web3 from 'web3';
+import web3core from 'web3-core';
 import { JsonRpcProvider } from '../../../index';
 import { TransactionReceipt } from '../../../types/Transaction.types';
 import { rpcUrls } from '../rpc-urls';
@@ -8,37 +10,102 @@ const rpcUrl = rpcUrls.mainnet;
 
 describe('provider.getTransactionReceipt', () => {
   function testTransactionReceiptEquality(
-    transactionReceipt1: ethers.providers.TransactionReceipt,
+    transactionReceipt1:
+      | ethers.providers.TransactionReceipt
+      | web3core.Transaction,
     transactionReceipt2: TransactionReceipt,
   ) {
-    // requires manually comparing values via bigNum conversion
-    const bignumCheckKeys = [
-      'gasUsed',
-      'cumulativeGasUsed',
-      'effectiveGasPrice',
-    ];
-    const omittedTransactionReceipt1 = omit(transactionReceipt1, [
-      ...bignumCheckKeys,
-    ]);
-    const omittedTransactionReceipt2 = omit(transactionReceipt2, [
-      ...bignumCheckKeys,
-    ]);
+    let typeCheckKeys: Array<string> = [];
+    let omittable1: Array<string> = [];
+    let omittable2: Array<string> = [];
+    if (
+      (transactionReceipt1 as ethers.providers.TransactionReceipt).confirmations
+    ) {
+      // only ethers response has confirmations
+      // requires manually comparing values via bigNum conversion
+      typeCheckKeys = ['gasUsed', 'cumulativeGasUsed', 'effectiveGasPrice'];
+      omittable1 = typeCheckKeys;
+      omittable2 = typeCheckKeys;
+
+      typeCheckKeys.forEach((key) => {
+        expect((transactionReceipt1 as any)[key].toString()).toBe(
+          (transactionReceipt2 as any)[key].toString(),
+        );
+      });
+
+      expect(
+        Math.abs(
+          (transactionReceipt1 as ethers.providers.TransactionReceipt)
+            .confirmations - transactionReceipt2.confirmations,
+        ),
+      ).toBeLessThan(3);
+    } else {
+      typeCheckKeys = [
+        'cumulativeGasUsed',
+        'effectiveGasPrice',
+        'from',
+        'gasUsed',
+        'status',
+        'to',
+        'type',
+      ];
+      omittable1 = typeCheckKeys;
+      omittable2 = ['byzantium', 'confirmations', ...typeCheckKeys];
+
+      typeCheckKeys.forEach((key) => {
+        switch (key) {
+          case 'cumulativeGasUsed':
+          case 'effectiveGasPrice':
+          case 'gasUsed':
+            expect((transactionReceipt1 as any)[key].toString()).toBe(
+              (transactionReceipt2 as any)[key].toString(),
+            );
+            break;
+          case 'from':
+          case 'to':
+            expect((transactionReceipt1 as any)[key]).toBe(
+              (transactionReceipt2 as any)[key].toLowerCase(),
+            );
+            break;
+        }
+      });
+    }
+
+    const omittedTransactionReceipt1 = omit(transactionReceipt1, omittable1) as
+      | TransactionReceipt
+      | web3core.TransactionReceipt;
+    const omittedTransactionReceipt2 = omit(transactionReceipt2, omittable2) as
+      | TransactionReceipt
+      | web3core.TransactionReceipt;
+    omittedTransactionReceipt1.logs = (() => {
+      const logs: any = [];
+      omittedTransactionReceipt1.logs.forEach((log) => {
+        logs.push(omit(log, ['id', 'removed']));
+      });
+      return logs as any;
+    })();
+
     expect(omittedTransactionReceipt1).toStrictEqual(
       omittedTransactionReceipt2,
     );
-    expect(
-      Math.abs(
-        transactionReceipt1.confirmations - transactionReceipt2.confirmations,
-      ),
-    ).toBeLessThan(3);
-    bignumCheckKeys.forEach((key) => {
-      const ethersKey = key as keyof ethers.providers.TransactionResponse;
-      expect((transactionReceipt1 as any)[ethersKey].toString()).toBe(
-        (transactionReceipt2 as any)[key].toString(),
-      );
-    });
   }
-  it('should match ethers and essential-eth', async () => {
+  it('should match web3.js', async () => {
+    const transactionHash =
+      '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
+    const web3Provider = new Web3(rpcUrl);
+    const essentialEthProvider = new JsonRpcProvider(rpcUrl);
+    const [web3TransactionReceipt, essentialEthTransactionReceipt] =
+      await Promise.all([
+        web3Provider.eth.getTransactionReceipt(transactionHash),
+        essentialEthProvider.getTransactionReceipt(transactionHash),
+      ]);
+
+    testTransactionReceiptEquality(
+      web3TransactionReceipt as any,
+      essentialEthTransactionReceipt,
+    );
+  });
+  it('should match ethers', async () => {
     const transactionHash =
       '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
     const ethersProvider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);

--- a/src/providers/test/json-rpc-provider/get-transaction-receipt.test.ts
+++ b/src/providers/test/json-rpc-provider/get-transaction-receipt.test.ts
@@ -7,9 +7,9 @@ import { rpcUrls } from '../rpc-urls';
 const rpcUrl = rpcUrls.mainnet;
 
 describe('provider.getTransactionReceipt', () => {
-  function testTransactionEquality(
-    transaction1: ethers.providers.TransactionReceipt,
-    transaction2: TransactionReceipt,
+  function testTransactionReceiptEquality(
+    transactionReceipt1: ethers.providers.TransactionReceipt,
+    transactionReceipt2: TransactionReceipt,
   ) {
     // requires manually comparing values via bigNum conversion
     const bignumCheckKeys = [
@@ -17,37 +17,27 @@ describe('provider.getTransactionReceipt', () => {
       'cumulativeGasUsed',
       'effectiveGasPrice',
     ];
-    const omittedTransaction1 = omit(transaction1, [
-      'logs', // temporary
+    const omittedTransactionReceipt1 = omit(transactionReceipt1, [
       ...bignumCheckKeys,
     ]);
-    const omittedTransaction2 = omit(transaction2, [
-      'logs', // temporary
+    const omittedTransactionReceipt2 = omit(transactionReceipt2, [
       ...bignumCheckKeys,
     ]);
-    expect(omittedTransaction1).toStrictEqual(omittedTransaction2);
+    expect(omittedTransactionReceipt1).toStrictEqual(
+      omittedTransactionReceipt2,
+    );
     expect(
-      Math.abs(transaction1.confirmations - transaction2.confirmations),
+      Math.abs(
+        transactionReceipt1.confirmations - transactionReceipt2.confirmations,
+      ),
     ).toBeLessThan(3);
     bignumCheckKeys.forEach((key) => {
       const ethersKey = key as keyof ethers.providers.TransactionResponse;
-      expect((transaction1 as any)[ethersKey].toString()).toBe(
-        (transaction2 as any)[key].toString(),
+      expect((transactionReceipt1 as any)[ethersKey].toString()).toBe(
+        (transactionReceipt2 as any)[key].toString(),
       );
     });
   }
-  // it('should match web3 and essential-eth', async () => {
-  //   const transactionHash =
-  //     '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
-  //   const web3Provider = new Web3(rpcUrl);
-  //   const essentialEthProvider = new JsonRpcProvider(rpcUrl);
-  //   const [web3Transaction, essentialEthTransaction] = await Promise.all([
-  //     web3Provider.eth.getTransaction(transactionHash),
-  //     essentialEthProvider.getTransaction(transactionHash),
-  //   ]);
-
-  //   testTransactionEquality(web3Transaction as any, essentialEthTransaction);
-  // });
   it('should match ethers and essential-eth', async () => {
     const transactionHash =
       '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
@@ -59,7 +49,7 @@ describe('provider.getTransactionReceipt', () => {
         essentialEthProvider.getTransactionReceipt(transactionHash),
       ]);
 
-    testTransactionEquality(
+    testTransactionReceiptEquality(
       ethersTransactionReceipt,
       essentialEthTransactionReceipt,
     );

--- a/src/providers/test/json-rpc-provider/get-transaction.test.ts
+++ b/src/providers/test/json-rpc-provider/get-transaction.test.ts
@@ -1,5 +1,8 @@
 import { ethers } from 'ethers';
 import omit from 'just-omit';
+import Web3 from 'web3';
+import web3core from 'web3-core';
+import { hexToDecimal } from '../../../classes/utils/hex-to-decimal';
 import { JsonRpcProvider } from '../../../index';
 import { TransactionResponse } from '../../../types/Transaction.types';
 import { rpcUrls } from '../rpc-urls';
@@ -8,57 +11,96 @@ const rpcUrl = rpcUrls.mainnet;
 
 describe('provider.getTransaction', () => {
   function testTransactionEquality(
-    transaction1: ethers.providers.TransactionResponse,
+    transaction1: ethers.providers.TransactionResponse | web3core.Transaction,
     transaction2: TransactionResponse,
   ) {
-    // requires manually comparing values via bigNum conversion
-    const bignumCheckKeys = [
-      'value',
-      'gas',
-      'gasPrice',
-      'maxFeePerGas',
-      'maxPriorityFeePerGas',
-      'confirmations',
-    ];
-    const omittedTransaction1 = omit(transaction1, [
-      'wait', // ethers injects this to allow you to wait on a certain confirmation count
-      'creates', // ethers injects this custom https://github.com/ethers-io/ethers.js/blob/948f77050dae884fe88932fd88af75560aac9d78/packages/providers/src.ts/formatter.ts#L336
-      'data', // ethers renames input to data https://github.com/ethers-io/ethers.js/blob/948f77050dae884fe88932fd88af75560aac9d78/packages/providers/src.ts/formatter.ts#L331
-      'gasLimit', // ethers renames gas to gasLimit https://github.com/ethers-io/ethers.js/blob/948f77050dae884fe88932fd88af75560aac9d78/packages/providers/src.ts/formatter.ts#L320
-      'input',
-      ...bignumCheckKeys,
-    ]);
-    const omittedTransaction2 = omit(transaction2, [
-      'input', // ee proxies exactly this from the eth node
-      ...bignumCheckKeys,
-    ]);
-    expect(omittedTransaction1).toStrictEqual(omittedTransaction2);
-    expect(
-      Math.abs(transaction1.confirmations - transaction2.confirmations),
-    ).toBeLessThan(3);
-    bignumCheckKeys.forEach((key) => {
-      let ethersKey = key as keyof ethers.providers.TransactionResponse;
-      if (key === 'gas') {
-        ethersKey = 'gasLimit';
-      }
-      expect((transaction1 as any)[ethersKey].toString()).toBe(
-        (transaction2 as any)[key].toString(),
-      );
-    });
-  }
-  // it('should match web3 and essential-eth', async () => {
-  //   const transactionHash =
-  //     '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
-  //   const web3Provider = new Web3(rpcUrl);
-  //   const essentialEthProvider = new JsonRpcProvider(rpcUrl);
-  //   const [web3Transaction, essentialEthTransaction] = await Promise.all([
-  //     web3Provider.eth.getTransaction(transactionHash),
-  //     essentialEthProvider.getTransaction(transactionHash),
-  //   ]);
+    let numCheckKeys: Array<string> = [];
+    let omittable1: Array<string> = [];
+    let omittable2: Array<string> = [];
+    if ((transaction1 as ethers.providers.TransactionResponse).confirmations) {
+      // only the ethers response has confirmations
+      // requires manually comparing values via bigNum conversion
+      numCheckKeys = [
+        'value',
+        'gas',
+        'gasPrice',
+        'maxFeePerGas',
+        'maxPriorityFeePerGas',
+        'confirmations',
+      ];
 
-  //   testTransactionEquality(web3Transaction as any, essentialEthTransaction);
-  // });
-  it('should match ethers and essential-eth', async () => {
+      omittable1 = [
+        'wait', // ethers injects this to allow you to wait on a certain confirmation count
+        'creates', // ethers injects this custom https://github.com/ethers-io/ethers.js/blob/948f77050dae884fe88932fd88af75560aac9d78/packages/providers/src.ts/formatter.ts#L336
+        'data', // ethers renames input to data https://github.com/ethers-io/ethers.js/blob/948f77050dae884fe88932fd88af75560aac9d78/packages/providers/src.ts/formatter.ts#L331
+        'gasLimit', // ethers renames gas to gasLimit https://github.com/ethers-io/ethers.js/blob/948f77050dae884fe88932fd88af75560aac9d78/packages/providers/src.ts/formatter.ts#L320
+        'input',
+        ...numCheckKeys,
+      ];
+
+      omittable2 = ['input', ...numCheckKeys];
+
+      numCheckKeys.forEach((key) => {
+        let ethersKey = key as keyof ethers.providers.TransactionResponse;
+        if (key === 'gas') {
+          ethersKey = 'gasLimit';
+        }
+        expect((transaction1 as any)[ethersKey].toString()).toBe(
+          (transaction2 as any)[key].toString(),
+        );
+      });
+
+      expect(
+        Math.abs(
+          (transaction1 as ethers.providers.TransactionResponse).confirmations -
+            transaction2.confirmations,
+        ),
+      ).toBeLessThan(3);
+    } else {
+      numCheckKeys = [
+        'chainId',
+        'gas',
+        'gasPrice',
+        'maxFeePerGas',
+        'maxPriorityFeePerGas',
+        'v',
+        'value',
+      ];
+      omittable1 = [...numCheckKeys];
+      omittable2 = ['confirmations', ...numCheckKeys];
+
+      numCheckKeys.forEach((key) => {
+        if (
+          typeof (transaction1 as any)[key] === 'string' &&
+          (transaction1 as any)[key].startsWith('0x')
+        ) {
+          (transaction1 as any)[key] = Number(
+            hexToDecimal((transaction1 as any)[key]),
+          );
+        }
+        expect((transaction1 as any)[key].toString()).toBe(
+          (transaction2 as any)[key].toString(),
+        );
+      });
+    }
+
+    const omittedTransaction1 = omit(transaction1, omittable1);
+    const omittedTransaction2 = omit(transaction2, omittable2);
+    expect(omittedTransaction1).toStrictEqual(omittedTransaction2);
+  }
+  it('should match web3.js', async () => {
+    const transactionHash =
+      '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
+    const web3Provider = new Web3(rpcUrl);
+    const essentialEthProvider = new JsonRpcProvider(rpcUrl);
+    const [web3Transaction, essentialEthTransaction] = await Promise.all([
+      web3Provider.eth.getTransaction(transactionHash),
+      essentialEthProvider.getTransaction(transactionHash),
+    ]);
+
+    testTransactionEquality(web3Transaction, essentialEthTransaction);
+  });
+  it('should match ethers.js', async () => {
     const transactionHash =
       '0x9014ae6ef92464338355a79e5150e542ff9a83e2323318b21f40d6a3e65b4789';
     const ethersProvider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);

--- a/src/types/Transaction.types.ts
+++ b/src/types/Transaction.types.ts
@@ -27,6 +27,10 @@ export type TransactionResponse = Modify<
   }
 >;
 
+/**
+ * Type that contains information from the receipt of a transaction
+ * * Similar to [`Type TransactionReceipt on ethers.providers`](https://docs.ethers.io/v5/api/providers/types/#providers-TransactionReceipt)
+ */
 export type TransactionReceipt = Modify<
   RPCTransactionReceipt,
   {

--- a/src/types/Transaction.types.ts
+++ b/src/types/Transaction.types.ts
@@ -47,6 +47,19 @@ export type TransactionReceipt = Modify<
   }
 >;
 
+/**
+ * Type for the logs that are included in transaction receipts
+ * * Similar to [`Type Log on ethers.providers`](https://docs.ethers.io/v5/api/providers/types/#providers-Log)
+ */
+export type Log = Modify<
+  RPCLog,
+  {
+    blockNumber: number;
+    logNumber: number;
+    transactionIndex: number;
+  }
+>;
+
 export type BlockTransactionResponse = Omit<
   TransactionResponse,
   'maxFeePerGas' | 'maxPriorityFeePerGas'
@@ -80,7 +93,7 @@ export interface RPCTransactionReceipt {
   effectiveGasPrice: string;
   from: string;
   gasUsed: string;
-  logs: Array<Log>;
+  logs: Array<RPCLog>;
   logsBloom: string;
   status: string;
   to: string;
@@ -89,7 +102,7 @@ export interface RPCTransactionReceipt {
   type: string;
 }
 
-export interface Log {
+export interface RPCLog {
   address: string;
   blockHash: string;
   blockNumber: string;

--- a/src/types/Transaction.types.ts
+++ b/src/types/Transaction.types.ts
@@ -3,11 +3,10 @@ import { TinyBig } from '../shared/tiny-big/tiny-big';
 type Modify<T, R> = Omit<T, keyof R> & R;
 export interface RPCTransaction extends RPCBlockTransaction {
   // not in getBlock transactions, only in getTransaction response
-
   maxFeePerGas: string /* "0xfc21e1832", */;
   maxPriorityFeePerGas: string /* "0x59682f00" */;
 }
-// exact type returned from JSON RPC
+
 export type TransactionResponse = Modify<
   RPCTransaction,
   {
@@ -27,6 +26,22 @@ export type TransactionResponse = Modify<
     confirmations: number;
   }
 >;
+
+export type TransactionReceiptResponse = Modify<
+  RPCTransactionReceipt,
+  {
+    blockNumber: number;
+    cumulativeGasUsed: TinyBig;
+    effectiveGasPrice: TinyBig;
+    gasUsed: TinyBig;
+    status: number;
+    transactionIndex: number;
+    type: number;
+  } & {
+    confirmations: number;
+  }
+>;
+
 export type BlockTransactionResponse = Omit<
   TransactionResponse,
   'maxFeePerGas' | 'maxPriorityFeePerGas'
@@ -50,4 +65,33 @@ export interface RPCBlockTransaction {
   type: string;
   v: string;
   value: string;
+}
+
+export interface RPCTransactionReceipt {
+  blockHash: string;
+  blockNumber: string;
+  contractAddress: string;
+  cumulativeGasUsed: string;
+  effectiveGasPrice: string;
+  from: string;
+  gasUsed: string;
+  logs: Array<Log>;
+  logsBloom: string;
+  status: string;
+  to: string;
+  transactionHash: string;
+  transactionIndex: string;
+  type: string;
+}
+
+export interface Log {
+  address: string;
+  blockHash: string;
+  blockNumber: string;
+  data: string;
+  logIndex: string;
+  removed: boolean;
+  topics: Array<string>;
+  transactionHash: string;
+  transactionIndex: string;
 }

--- a/src/types/Transaction.types.ts
+++ b/src/types/Transaction.types.ts
@@ -38,6 +38,7 @@ export type TransactionReceipt = Modify<
     cumulativeGasUsed: TinyBig;
     effectiveGasPrice: TinyBig;
     gasUsed: TinyBig;
+    logs: Array<Log>;
     status: number;
     transactionIndex: number;
     type: number;
@@ -52,10 +53,10 @@ export type TransactionReceipt = Modify<
  * * Similar to [`Type Log on ethers.providers`](https://docs.ethers.io/v5/api/providers/types/#providers-Log)
  */
 export type Log = Modify<
-  RPCLog,
+  Omit<RPCLog, 'removed'>,
   {
     blockNumber: number;
-    logNumber: number;
+    logIndex: number;
     transactionIndex: number;
   }
 >;
@@ -108,7 +109,7 @@ export interface RPCLog {
   blockNumber: string;
   data: string;
   logIndex: string;
-  removed: boolean;
+  removed?: boolean;
   topics: Array<string>;
   transactionHash: string;
   transactionIndex: string;

--- a/src/types/Transaction.types.ts
+++ b/src/types/Transaction.types.ts
@@ -27,7 +27,7 @@ export type TransactionResponse = Modify<
   }
 >;
 
-export type TransactionReceiptResponse = Modify<
+export type TransactionReceipt = Modify<
   RPCTransactionReceipt,
   {
     blockNumber: number;
@@ -38,6 +38,7 @@ export type TransactionReceiptResponse = Modify<
     transactionIndex: number;
     type: number;
   } & {
+    byzantium: boolean;
     confirmations: number;
   }
 >;


### PR DESCRIPTION
Closes #21 

- [x] Add `getTransaction` function
- [x] Add necessary types
- [x] Add `cleanTransactionReceipt` function
- [x] Add tests to compare to ethers
- [x] DRY code for parsing `RPCTransaction` and `RPCTransactionReceipt`
- [x] Document `TransactionReceipt` type
- [x] Parse and update types of the logs passed through a transaction receipt
